### PR TITLE
Support high-level tract constrictions.

### DIFF
--- a/data.w
+++ b/data.w
@@ -183,6 +183,8 @@ typedef struct {
 @t n=44, it should be 28.@>@/
     int nose_start; @t \indent $n - nose\_length + 1$, or 17 @>@/
 @t tip\_start is a constant set to 32 @>@/
+    int throat_start;
+    int oral_start;
     int tip_start;
     SPFLOAT @, noseL[28];
     SPFLOAT @, noseR[28];
@@ -229,4 +231,14 @@ static SPFLOAT move_towards(SPFLOAT current, SPFLOAT target,
         tmp = current - amt_down;
         return MAX(tmp, target);
     }
+}
+
+static SPFLOAT clamp(SPFLOAT x, SPFLOAT min, SPFLOAT max)
+{
+    return x < min ? min : (x > max ? max : x);
+}
+
+static SPFLOAT lerp(SPFLOAT x0, SPFLOAT x1, SPFLOAT t)
+{
+    return x0 * (1 - t) + x1 * t;
 }

--- a/header.w
+++ b/header.w
@@ -23,6 +23,11 @@ to declare setter/getter functions for any user parameters.
 #define SP_VOC
 typedef struct sp_voc sp_voc;
 
+typedef struct {
+    SPFLOAT index;
+    SPFLOAT diameter;
+} sp_voc_tract_position;
+
 int sp_voc_create(sp_voc **voc);
 int sp_voc_destroy(sp_voc **voc);
 int sp_voc_init(sp_data *sp, sp_voc *voc);
@@ -50,8 +55,9 @@ void sp_voc_set_diameters(sp_voc *voc,
     int blade_start,
     int lip_start,
     int tip_start,
-    SPFLOAT tongue_index,
-    SPFLOAT tongue_diameter,
+    sp_voc_tract_position tongue_position,
+    sp_voc_tract_position *constrictions,
+    int num_constrictions,
     SPFLOAT *diameters);
 
 int sp_voc_get_counter(sp_voc *voc);

--- a/tract.w
+++ b/tract.w
@@ -56,6 +56,8 @@ tr->last_obstruction = -1;
 tr->movement_speed = 15;
 tr->lip_output = 0;
 tr->nose_output = 0;
+tr->throat_start = 2;
+tr->oral_start = 25;
 tr->tip_start = 32;
 
 @ Several floating-point arrays are needed for the scattering junctions. 


### PR DESCRIPTION
In the API, constrictions are provided as a single point.  The
implementation expands each to a smooth range the tract diameter
array as is done in Pink Trombone.

Addresses issue #3 
TODO: documentation
